### PR TITLE
Fix: add recursive inode/dentry invalidation and API smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f251e5fd17ca8206cad5d8863f080d11d29646b21a614dba1f1912fa6e4747"
+checksum = "5792186098090fbf991681085fbbfd0a0ea89ec05da8c049a1f117ce4ba1d23d"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,12 @@ path = "src/lib.rs"
 anyhow = "1"
 clap = { version = "4.0.18", features = ["derive", "cargo"] }
 flexi_logger = { version = "0.25", features = ["compress"] }
-fuse-backend-rs = "^0.12.0"
+fuse-backend-rs = {git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git"}
 hex = "0.4.3"
 hyper = "0.14.11"
 hyperlocal = "0.8.0"
 lazy_static = "1"
-libc = "0.2"
+libc = "0.2.174"
 log = "0.4.8"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }

--- a/clib/Cargo.toml
+++ b/clib/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 libc = "0.2.137"
 log = "0.4.17"
-fuse-backend-rs = "^0.12.0"
+fuse-backend-rs = {git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git"}
 nydus-api = { version = "0.4.0", path = "../api" }
 nydus-rafs = { version = "0.4.0", path = "../rafs" }
 nydus-storage = { version = "0.7.0", path = "../storage" }

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -19,7 +19,7 @@ nix = "0.24"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
 vm-memory = "0.14.1"
-fuse-backend-rs = "^0.12.0"
+fuse-backend-rs = {git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git"}
 thiserror = "1"
 
 nydus-api = { version = "0.4.0", path = "../api" }

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -348,6 +348,11 @@ impl Rafs {
         self.sb.superblock.root_ino()
     }
 
+    pub fn get_root_inode(&self) -> Result<Arc<dyn RafsInode>> {
+        let root_ino = self.root_ino();
+        self.sb.get_inode(root_ino, self.digest_validate)
+    }
+
     fn do_prefetch(
         root_ino: u64,
         mut reader: RafsIoReader,

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [dependencies]
 bytes = { version = "1", optional = true }
 dbs-allocator = { version = "0.1.1", optional = true }
-fuse-backend-rs = { version = "^0.12.0", features = ["persist"] }
+fuse-backend-rs = {git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", features=["persist"]}
 libc = "0.2"
 log = "0.4.8"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }

--- a/service/src/fs_service.rs
+++ b/service/src/fs_service.rs
@@ -86,7 +86,7 @@ impl FsBackendCollection {
         Ok(())
     }
 
-    fn del(&mut self, id: &str) {
+    pub fn del(&mut self, id: &str) {
         self.0.remove(id);
     }
 }
@@ -99,7 +99,7 @@ pub trait FsService: Send + Sync {
 
     /// Get the [BackFileSystem](https://docs.rs/fuse-backend-rs/latest/fuse_backend_rs/api/vfs/type.BackFileSystem.html)
     /// object associated with a mount point.
-    fn backend_from_mountpoint(&self, mp: &str) -> Result<Option<Arc<BackFileSystem>>> {
+    fn backend_from_mountpoint(&self, mp: &str) -> Result<Option<(Arc<BackFileSystem>, u8)>> {
         self.get_vfs().get_rootfs(mp).map_err(|e| e.into())
     }
 
@@ -133,7 +133,7 @@ pub trait FsService: Send + Sync {
 
     /// Remount a filesystem instance.
     fn remount(&self, cmd: FsBackendMountCmd) -> Result<()> {
-        let rootfs = self
+        let (rootfs, _) = self
             .backend_from_mountpoint(&cmd.mountpoint)?
             .ok_or(Error::NotFound)?;
         let mut bootstrap = <dyn RafsIoRead>::from_file(&cmd.source)?;
@@ -201,7 +201,7 @@ pub trait FsService: Send + Sync {
 
     /// Export information about the filesystem service.
     fn export_backend_info(&self, mountpoint: &str) -> Result<String> {
-        let fs = self
+        let (fs, _) = self
             .backend_from_mountpoint(mountpoint)?
             .ok_or(Error::NotFound)?;
         let any_fs = fs.deref().as_any();

--- a/service/src/fs_service.rs
+++ b/service/src/fs_service.rs
@@ -23,6 +23,7 @@ use fuse_backend_rs::overlayfs::{config::Config as overlay_config, OverlayFs};
 use fuse_backend_rs::passthrough::{CachePolicy, Config as passthrough_config, PassthroughFs};
 use nydus_api::ConfigV2;
 use nydus_rafs::fs::Rafs;
+use nydus_rafs::metadata::RafsInode;
 use nydus_rafs::{RafsError, RafsIoRead};
 use nydus_storage::factory::BLOB_FACTORY;
 use serde::{Deserialize, Serialize};
@@ -31,6 +32,8 @@ use versionize_derive::Versionize;
 
 use crate::upgrade::UpgradeManager;
 use crate::{Error, FsBackendDescriptor, FsBackendType, Result};
+
+const ROOT_PARENT_INO: u64 = 1;
 
 /// Request structure to mount a filesystem instance.
 #[derive(Clone, Versionize, Debug)]
@@ -178,9 +181,23 @@ pub trait FsService: Send + Sync {
 
     /// Umount a filesystem instance.
     fn umount(&self, cmd: FsBackendUmountCmd) -> Result<()> {
-        let _ = self
+        let (fs, fs_idx) = self
             .backend_from_mountpoint(&cmd.mountpoint)?
             .ok_or(Error::NotFound)?;
+
+        if self.is_fuse() {
+            if let Some(rafs) = fs.deref().as_any().downcast_ref::<Rafs>() {
+                let root_ino = rafs.get_root_inode().unwrap();
+                self.walk_and_notify_invalidation(
+                    ROOT_PARENT_INO,
+                    cmd.mountpoint.trim_start_matches('/'),
+                    root_ino,
+                    fs_idx,
+                )?;
+            }
+        }
+
+        drop(fs);
 
         self.get_vfs().umount(&cmd.mountpoint)?;
         self.backend_collection().del(&cmd.mountpoint);
@@ -215,6 +232,21 @@ pub trait FsService: Send + Sync {
     /// Export metrics about in-flight operations.
     fn export_inflight_ops(&self) -> Result<Option<String>>;
 
+    /// Recursively walk the inode tree and send cache invalidation notifications.
+    fn walk_and_notify_invalidation(
+        &self,
+        _parent_kernel_ino: u64,
+        _cur_name: &str,
+        _cur_inode: Arc<dyn RafsInode>,
+        _fs_idx: u8,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Check whether the filesystem service is a FUSE service.
+    fn is_fuse(&self) -> bool {
+        false
+    }
     /// Cast `self` to trait object of [Any] to support object downcast.
     fn as_any(&self) -> &dyn Any;
 }

--- a/service/src/fusedev.rs
+++ b/service/src/fusedev.rs
@@ -5,8 +5,11 @@
 
 //! Nydus FUSE filesystem daemon.
 
+use core::option::Option::None;
+use nydus_rafs::fs::Rafs;
+use nydus_rafs::metadata::{RafsInode, RafsInodeWalkAction};
 use std::any::Any;
-use std::ffi::{CStr, CString};
+use std::ffi::{CStr, CString, OsStr, OsString};
 use std::fs::metadata;
 use std::io::{Error, ErrorKind, Result};
 use std::ops::Deref;
@@ -29,20 +32,24 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use fuse_backend_rs::abi::fuse_abi::{InHeader, OutHeader};
 use fuse_backend_rs::api::server::{MetricsHook, Server};
 use fuse_backend_rs::api::Vfs;
-use fuse_backend_rs::transport::{FuseChannel, FuseSession};
+use fuse_backend_rs::transport::{FuseChannel, FuseSession, FuseSessionExt};
 use mio::Waker;
 #[cfg(target_os = "linux")]
 use nix::sys::stat::{major, minor};
 use nydus_api::BuildTimeInfo;
+use nydus_storage::factory::BLOB_FACTORY;
 use serde::Serialize;
 
 use crate::daemon::{
     DaemonState, DaemonStateMachineContext, DaemonStateMachineInput, DaemonStateMachineSubscriber,
     NydusDaemon,
 };
-use crate::fs_service::{FsBackendCollection, FsBackendMountCmd, FsService};
+use crate::fs_service::{FsBackendCollection, FsBackendMountCmd, FsBackendUmountCmd, FsService};
 use crate::upgrade::{self, FailoverPolicy, UpgradeManager};
 use crate::{Error as NydusError, FsBackendType, Result as NydusResult};
+
+const FS_IDX_SHIFT: u64 = 56;
+const ROOT_PARENT_INO: u64 = 1;
 
 #[derive(Serialize)]
 struct FuseOp {
@@ -198,6 +205,93 @@ impl FusedevFsService {
 
         inflight_op
     }
+    fn walk_and_notify_invalidation(
+        &self,
+        path: &str,
+        inode: Arc<dyn RafsInode>,
+        fs_idx: u8,
+    ) -> Result<()> {
+        let mut stack = Vec::new();
+        stack.push((
+            ROOT_PARENT_INO,
+            path.trim_start_matches('/').to_string(),
+            inode.clone(),
+            false,
+        ));
+
+        while let Some((parent_kernel_ino, cur_name, cur_inode, visited)) = stack.pop() {
+            // Convert rafs inode to inode id used by kernel
+            let cur_kernel_ino = ((fs_idx as u64) << FS_IDX_SHIFT) | cur_inode.ino();
+
+            if !visited {
+                // Always push back with `visited = true` so we can do post-order processing
+                stack.push((parent_kernel_ino, cur_name.clone(), cur_inode.clone(), true));
+
+                // If directory, walk children
+                if cur_inode.is_dir() {
+                    let mut entries = Vec::new();
+                    let mut handler = |child: Option<Arc<dyn RafsInode>>,
+                                       name: OsString,
+                                       _ino: u64,
+                                       _offset: u64| {
+                        if name.as_os_str() != OsStr::new(".")
+                            && name.as_os_str() != OsStr::new("..")
+                        {
+                            if let Some(child_inode) = child {
+                                let child_name = name.to_string_lossy().to_string();
+                                let parent_kernel_ino =
+                                    ((fs_idx as u64) << FS_IDX_SHIFT) | cur_inode.ino();
+                                entries.push((parent_kernel_ino, child_name, child_inode));
+                            }
+                        }
+                        Ok(RafsInodeWalkAction::Continue)
+                    };
+
+                    if let Err(e) = cur_inode.walk_children_inodes(0, &mut handler) {
+                        error!(
+                            "Failed to walk children of inode {:?}: {:?}",
+                            cur_inode.ino(),
+                            e
+                        );
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!(
+                                "failed to walk children of inode {}: {}",
+                                cur_inode.ino(),
+                                e
+                            ),
+                        ));
+                    }
+
+                    for entry in entries {
+                        stack.push((entry.0, entry.1, entry.2, false));
+                    }
+                }
+            } else {
+                let cstr_name =
+                    CString::new(cur_name.clone()).map_err(|_| eother!("invalid file name"))?;
+                // Invalidate inode cache
+                self.session.lock().unwrap().with_writer(|writer| {
+                    if let Err(e) = self.server.notify_inval_inode(writer, cur_kernel_ino, 0, 0) {
+                        warn!("notify_inval_inode failed: {} {:?}", cur_name, e);
+                    }
+                });
+
+                // Invalidate entry cache
+                self.session.lock().unwrap().with_writer(|writer| {
+                    if let Err(e) = self.server.notify_inval_entry(
+                        writer,
+                        parent_kernel_ino,
+                        cstr_name.as_c_str(),
+                    ) {
+                        warn!("notify_inval_entry failed: {} {:?}", cur_name, e);
+                    }
+                });
+            }
+        }
+
+        Ok(())
+    }
 
     fn umount(&self) -> NydusResult<()> {
         let mut session = self.session.lock().expect("Not expect poisoned lock.");
@@ -237,6 +331,31 @@ impl FsService for FusedevFsService {
         }
     }
 
+    fn umount(&self, cmd: FsBackendUmountCmd) -> NydusResult<()> {
+        let (fs, fs_idx) = self
+            .backend_from_mountpoint(&cmd.mountpoint)?
+            .ok_or(NydusError::NotFound)?;
+        let rafs = fs.deref().as_any().downcast_ref::<Rafs>().unwrap();
+
+        let root_ino = rafs.get_root_inode().unwrap();
+        self.walk_and_notify_invalidation(&cmd.mountpoint, root_ino, fs_idx)
+            .map_err(|e: Error| NydusError::WalkNotifyInvalidation(e))?;
+
+        drop(fs);
+
+        self.get_vfs().umount(&cmd.mountpoint)?;
+        self.backend_collection().del(&cmd.mountpoint);
+        if let Some(mut mgr_guard) = self.upgrade_mgr() {
+            // Remove mount opaque from UpgradeManager
+            mgr_guard.remove_mounts_state(cmd);
+            mgr_guard.save_vfs_stat(self.get_vfs())?;
+        }
+
+        debug!("try to gc unused blobs");
+        BLOB_FACTORY.gc(None);
+
+        Ok(())
+    }
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/service/src/fusedev.rs
+++ b/service/src/fusedev.rs
@@ -205,90 +205,57 @@ impl FusedevFsService {
 
         inflight_op
     }
+
     fn walk_and_notify_invalidation(
         &self,
-        path: &str,
-        inode: Arc<dyn RafsInode>,
+        parent_kernel_ino: u64,
+        cur_name: &str,
+        cur_inode: Arc<dyn RafsInode>,
         fs_idx: u8,
     ) -> Result<()> {
-        let mut stack = Vec::new();
-        stack.push((
-            ROOT_PARENT_INO,
-            path.trim_start_matches('/').to_string(),
-            inode.clone(),
-            false,
-        ));
+        let cur_kernel_ino = ((fs_idx as u64) << FS_IDX_SHIFT) | cur_inode.ino();
 
-        while let Some((parent_kernel_ino, cur_name, cur_inode, visited)) = stack.pop() {
-            // Convert rafs inode to inode id used by kernel
-            let cur_kernel_ino = ((fs_idx as u64) << FS_IDX_SHIFT) | cur_inode.ino();
-
-            if !visited {
-                // Always push back with `visited = true` so we can do post-order processing
-                stack.push((parent_kernel_ino, cur_name.clone(), cur_inode.clone(), true));
-
-                // If directory, walk children
-                if cur_inode.is_dir() {
-                    let mut entries = Vec::new();
-                    let mut handler = |child: Option<Arc<dyn RafsInode>>,
-                                       name: OsString,
-                                       _ino: u64,
-                                       _offset: u64| {
-                        if name.as_os_str() != OsStr::new(".")
-                            && name.as_os_str() != OsStr::new("..")
-                        {
-                            if let Some(child_inode) = child {
-                                let child_name = name.to_string_lossy().to_string();
-                                let parent_kernel_ino =
-                                    ((fs_idx as u64) << FS_IDX_SHIFT) | cur_inode.ino();
-                                entries.push((parent_kernel_ino, child_name, child_inode));
+        // 先遍历子节点
+        if cur_inode.is_dir() {
+            let mut handler =
+                |child: Option<Arc<dyn RafsInode>>, name: OsString, _ino: u64, _offset: u64| {
+                    if name != OsStr::new(".") && name != OsStr::new("..") {
+                        if let Some(child_inode) = child {
+                            let child_name = name.to_string_lossy().to_string();
+                            // 递归调用自身
+                            if let Err(e) = self.walk_and_notify_invalidation(
+                                cur_kernel_ino,
+                                &child_name,
+                                child_inode,
+                                fs_idx,
+                            ) {
+                                warn!("recursive walk failed for {}: {:?}", child_name, e);
                             }
                         }
-                        Ok(RafsInodeWalkAction::Continue)
-                    };
+                    }
+                    Ok(RafsInodeWalkAction::Continue)
+                };
 
-                    if let Err(e) = cur_inode.walk_children_inodes(0, &mut handler) {
-                        error!(
-                            "Failed to walk children of inode {:?}: {:?}",
-                            cur_inode.ino(),
-                            e
-                        );
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!(
-                                "failed to walk children of inode {}: {}",
-                                cur_inode.ino(),
-                                e
-                            ),
-                        ));
-                    }
-
-                    for entry in entries {
-                        stack.push((entry.0, entry.1, entry.2, false));
-                    }
-                }
-            } else {
-                let cstr_name =
-                    CString::new(cur_name.clone()).map_err(|_| eother!("invalid file name"))?;
-                // Invalidate inode cache
-                self.session.lock().unwrap().with_writer(|writer| {
-                    if let Err(e) = self.server.notify_inval_inode(writer, cur_kernel_ino, 0, 0) {
-                        warn!("notify_inval_inode failed: {} {:?}", cur_name, e);
-                    }
-                });
-
-                // Invalidate entry cache
-                self.session.lock().unwrap().with_writer(|writer| {
-                    if let Err(e) = self.server.notify_inval_entry(
-                        writer,
-                        parent_kernel_ino,
-                        cstr_name.as_c_str(),
-                    ) {
-                        warn!("notify_inval_entry failed: {} {:?}", cur_name, e);
-                    }
-                });
-            }
+            cur_inode.walk_children_inodes(0, &mut handler)?;
         }
+
+        // === 后序处理：当前节点的缓存失效 ===
+        let cstr_name = CString::new(cur_name).map_err(|_| eother!("invalid file name"))?;
+        // Invalidate inode cache
+        self.session.lock().unwrap().with_writer(|writer| {
+            if let Err(e) = self.server.notify_inval_inode(writer, cur_kernel_ino, 0, 0) {
+                warn!("notify_inval_inode failed: {} {:?}", cur_name, e);
+            }
+        });
+
+        self.session.lock().unwrap().with_writer(|writer| {
+            if let Err(e) =
+                self.server
+                    .notify_inval_entry(writer, parent_kernel_ino, cstr_name.as_c_str())
+            {
+                warn!("notify_inval_entry failed: {} {:?}", cur_name, e);
+            }
+        });
 
         Ok(())
     }
@@ -338,8 +305,13 @@ impl FsService for FusedevFsService {
         let rafs = fs.deref().as_any().downcast_ref::<Rafs>().unwrap();
 
         let root_ino = rafs.get_root_inode().unwrap();
-        self.walk_and_notify_invalidation(&cmd.mountpoint, root_ino, fs_idx)
-            .map_err(|e: Error| NydusError::WalkNotifyInvalidation(e))?;
+        self.walk_and_notify_invalidation(
+            ROOT_PARENT_INO,
+            cmd.mountpoint.trim_start_matches('/'),
+            root_ino,
+            fs_idx,
+        )
+        .map_err(|e: Error| NydusError::WalkNotifyInvalidation(e))?;
 
         drop(fs);
 

--- a/service/src/fusedev.rs
+++ b/service/src/fusedev.rs
@@ -6,7 +6,6 @@
 //! Nydus FUSE filesystem daemon.
 
 use core::option::Option::None;
-use nydus_rafs::fs::Rafs;
 use nydus_rafs::metadata::{RafsInode, RafsInodeWalkAction};
 use std::any::Any;
 use std::ffi::{CStr, CString, OsStr, OsString};
@@ -37,19 +36,17 @@ use mio::Waker;
 #[cfg(target_os = "linux")]
 use nix::sys::stat::{major, minor};
 use nydus_api::BuildTimeInfo;
-use nydus_storage::factory::BLOB_FACTORY;
 use serde::Serialize;
 
 use crate::daemon::{
     DaemonState, DaemonStateMachineContext, DaemonStateMachineInput, DaemonStateMachineSubscriber,
     NydusDaemon,
 };
-use crate::fs_service::{FsBackendCollection, FsBackendMountCmd, FsBackendUmountCmd, FsService};
+use crate::fs_service::{FsBackendCollection, FsBackendMountCmd, FsService};
 use crate::upgrade::{self, FailoverPolicy, UpgradeManager};
 use crate::{Error as NydusError, FsBackendType, Result as NydusResult};
 
-const FS_IDX_SHIFT: u64 = 56;
-const ROOT_PARENT_INO: u64 = 1;
+const FS_IDX_SHIFT: u64 = 1;
 
 #[derive(Serialize)]
 struct FuseOp {
@@ -206,60 +203,6 @@ impl FusedevFsService {
         inflight_op
     }
 
-    fn walk_and_notify_invalidation(
-        &self,
-        parent_kernel_ino: u64,
-        cur_name: &str,
-        cur_inode: Arc<dyn RafsInode>,
-        fs_idx: u8,
-    ) -> Result<()> {
-        let cur_kernel_ino = ((fs_idx as u64) << FS_IDX_SHIFT) | cur_inode.ino();
-
-        // 先遍历子节点
-        if cur_inode.is_dir() {
-            let mut handler =
-                |child: Option<Arc<dyn RafsInode>>, name: OsString, _ino: u64, _offset: u64| {
-                    if name != OsStr::new(".") && name != OsStr::new("..") {
-                        if let Some(child_inode) = child {
-                            let child_name = name.to_string_lossy().to_string();
-                            // 递归调用自身
-                            if let Err(e) = self.walk_and_notify_invalidation(
-                                cur_kernel_ino,
-                                &child_name,
-                                child_inode,
-                                fs_idx,
-                            ) {
-                                warn!("recursive walk failed for {}: {:?}", child_name, e);
-                            }
-                        }
-                    }
-                    Ok(RafsInodeWalkAction::Continue)
-                };
-
-            cur_inode.walk_children_inodes(0, &mut handler)?;
-        }
-
-        // === 后序处理：当前节点的缓存失效 ===
-        let cstr_name = CString::new(cur_name).map_err(|_| eother!("invalid file name"))?;
-        // Invalidate inode cache
-        self.session.lock().unwrap().with_writer(|writer| {
-            if let Err(e) = self.server.notify_inval_inode(writer, cur_kernel_ino, 0, 0) {
-                warn!("notify_inval_inode failed: {} {:?}", cur_name, e);
-            }
-        });
-
-        self.session.lock().unwrap().with_writer(|writer| {
-            if let Err(e) =
-                self.server
-                    .notify_inval_entry(writer, parent_kernel_ino, cstr_name.as_c_str())
-            {
-                warn!("notify_inval_entry failed: {} {:?}", cur_name, e);
-            }
-        });
-
-        Ok(())
-    }
-
     fn umount(&self) -> NydusResult<()> {
         let mut session = self.session.lock().expect("Not expect poisoned lock.");
         session.umount().map_err(NydusError::SessionShutdown)?;
@@ -298,36 +241,65 @@ impl FsService for FusedevFsService {
         }
     }
 
-    fn umount(&self, cmd: FsBackendUmountCmd) -> NydusResult<()> {
-        let (fs, fs_idx) = self
-            .backend_from_mountpoint(&cmd.mountpoint)?
-            .ok_or(NydusError::NotFound)?;
-        let rafs = fs.deref().as_any().downcast_ref::<Rafs>().unwrap();
+    /// Recursively walk the inode tree and send cache invalidation notifications.
+    fn walk_and_notify_invalidation(
+        &self,
+        parent_kernel_ino: u64,
+        cur_name: &str,
+        cur_inode: Arc<dyn RafsInode>,
+        fs_idx: u8,
+    ) -> NydusResult<()> {
+        let cur_kernel_ino = ((fs_idx as u64) << FS_IDX_SHIFT) | cur_inode.ino();
 
-        let root_ino = rafs.get_root_inode().unwrap();
-        self.walk_and_notify_invalidation(
-            ROOT_PARENT_INO,
-            cmd.mountpoint.trim_start_matches('/'),
-            root_ino,
-            fs_idx,
-        )
-        .map_err(|e: Error| NydusError::WalkNotifyInvalidation(e))?;
+        if cur_inode.is_dir() {
+            let mut handler =
+                |child: Option<Arc<dyn RafsInode>>, name: OsString, _ino: u64, _offset: u64| {
+                    if name != OsStr::new(".") && name != OsStr::new("..") {
+                        if let Some(child_inode) = child {
+                            let child_name = name.to_string_lossy().to_string();
+                            // Recursive call
+                            if let Err(e) = self.walk_and_notify_invalidation(
+                                cur_kernel_ino,
+                                &child_name,
+                                child_inode,
+                                fs_idx,
+                            ) {
+                                warn!("recursive walk failed for {}: {:?}", child_name, e);
+                            }
+                        }
+                    }
+                    Ok(RafsInodeWalkAction::Continue)
+                };
 
-        drop(fs);
-
-        self.get_vfs().umount(&cmd.mountpoint)?;
-        self.backend_collection().del(&cmd.mountpoint);
-        if let Some(mut mgr_guard) = self.upgrade_mgr() {
-            // Remove mount opaque from UpgradeManager
-            mgr_guard.remove_mounts_state(cmd);
-            mgr_guard.save_vfs_stat(self.get_vfs())?;
+            cur_inode.walk_children_inodes(0, &mut handler)?;
         }
 
-        debug!("try to gc unused blobs");
-        BLOB_FACTORY.gc(None);
+        // === Post-order: invalidate cache of the current node ===
+        let cstr_name = CString::new(cur_name).map_err(|_| eother!("invalid file name"))?;
+        // Invalidate inode cache
+        self.session.lock().unwrap().with_writer(|writer| {
+            if let Err(e) = self.server.notify_inval_inode(writer, cur_kernel_ino, 0, 0) {
+                warn!("notify_inval_inode failed: {} {:?}", cur_name, e);
+            }
+        });
+
+        self.session.lock().unwrap().with_writer(|writer| {
+            if let Err(e) =
+                self.server
+                    .notify_inval_entry(writer, parent_kernel_ino, cstr_name.as_c_str())
+            {
+                warn!("notify_inval_entry failed: {} {:?}", cur_name, e);
+            }
+        });
 
         Ok(())
     }
+
+    /// Check whether the filesystem service is a FUSE service.
+    fn is_fuse(&self) -> bool {
+        true
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -106,6 +106,8 @@ pub enum Error {
     // Fuse session has been shutdown.
     #[error("FUSE session has been shut down, {0}")]
     SessionShutdown(FuseTransportError),
+    #[error("failed to walk and notify invalidation: {0}")]
+    WalkNotifyInvalidation(#[from] std::io::Error),
 
     // virtio-fs
     #[error("failed to handle event other than input event")]

--- a/smoke/tests/api_test.go
+++ b/smoke/tests/api_test.go
@@ -192,20 +192,11 @@ func (a *APIV1TestSuite) TestPrefetch(t *testing.T) {
 	_, err = nydusd.GetBlobCacheMetrics("/pseudo_fs_1")
 	require.NoError(t, err)
 }
-
 func (a *APIV1TestSuite) TestSubMountCache(t *testing.T) {
-
 	ctx := tool.DefaultContext(t)
 
 	ctx.PrepareWorkDir(t)
 	defer ctx.Destroy(t)
-
-	// lower contains more files than thinLower
-	lower := texture.MakeLowerLayer(t, filepath.Join(ctx.Env.WorkDir, "rootfs"))
-	thinLower := texture.MakeThinLowerLayer(t, filepath.Join(ctx.Env.WorkDir, "rootfs1"))
-
-	lowerBootstrap := a.buildLayer(t, ctx, lower)
-	thinLowerBootstrap := a.buildLayer(t, ctx, thinLower)
 
 	config := tool.NydusdConfig{
 		NydusdPath:  ctx.Binary.Nydusd,
@@ -220,7 +211,7 @@ func (a *APIV1TestSuite) TestSubMountCache(t *testing.T) {
 	require.NoError(t, err)
 	defer nydusd.Umount()
 
-	// child mount config template (copied every iteration)
+	// child mount config template
 	childTpl := tool.NydusdConfig{
 		NydusdPath:      ctx.Binary.Nydusd,
 		MountPath:       "/mount",
@@ -240,62 +231,145 @@ func (a *APIV1TestSuite) TestSubMountCache(t *testing.T) {
 	// mount prefix where the daemon actually mounts sub-mounts
 	mountPrefix := ctx.Env.WorkDir + "/mnt"
 
-	// iterate 256 times; first mount uses thinlower (without some files), subsequent mounts use Lower.
-	for i := 0; i < 256; i++ {
+	// iterate more than 255 times, e.g. 300
+	for i := 0; i < 300; i++ {
+		// 每次生成一个新的 layer，文件名和内容都不同
+		layer := texture.MakeMatrixLayer(
+			t,
+			filepath.Join(ctx.Env.WorkDir, fmt.Sprintf("rootfs-%d", i)),
+			fmt.Sprintf("%d", i),
+		)
+		bootstrap := a.buildLayer(t, ctx, layer)
+
 		curCfg := childTpl
-		if i == 0 {
-			curCfg.BootstrapPath = thinLowerBootstrap
-		} else {
-			curCfg.BootstrapPath = lowerBootstrap
-		}
+		curCfg.BootstrapPath = bootstrap
 		curCfg.MountPath = childTpl.MountPath + fmt.Sprintf("-%d", i)
+
 		err = nydusd.MountByAPI(curCfg)
 		require.NoError(t, err, "failed to mount by API at iteration %d", i)
 
 		fullMount := filepath.Join(mountPrefix, curCfg.MountPath)
 
-		// VerifyByPath validates the file tree and also triggers the construction of inode and dentry caches.
-		if i == 0 {
-			nydusd.VerifyByPath(t, thinLower.FileTree, curCfg.MountPath)
-		} else {
-			// Verify specific files exist
-			_, err := os.Stat(filepath.Join(fullMount, "dir-1/file-1"))
-			require.NoError(t, err, "stat file-1 failed")
-
-			// Verify file contents
-			data, err := os.ReadFile(filepath.Join(fullMount, "file-2"))
-			require.NoError(t, err, "fail to read file-2")
-			require.Equal(t, []byte("file-2"), data, "file-2")
-
-			//  Verify directory contents
-			ents, err := os.ReadDir(filepath.Join(fullMount, "dir-1"))
-			require.NoError(t, err, "readdir dir-1 failed")
-
-			names := make(map[string]bool)
-			for _, e := range ents {
-				names[e.Name()] = true
-			}
-			expected := []string{
-				"file-1-hardlink-1",
-				"file-1-hardlink-2",
-				"file-1-symlink-1",
-				"file-1-symlink-2",
-				"file-external-1",
-				"file-2",
-			}
-
-			// Ensure directory contains all expected entries
-			for _, name := range expected {
-				require.True(t, names[name], "dir-1 should contain %s", name)
-			}
-
-			nydusd.VerifyByPath(t, lower.FileTree, curCfg.MountPath)
-
+		// 校验文件内容
+		for _, fname := range []string{
+			fmt.Sprintf("matrix-file-%d-1", i),
+			fmt.Sprintf("matrix-file-%d-2", i),
+		} {
+			data, err := os.ReadFile(filepath.Join(fullMount, fname))
+			require.NoError(t, err, "failed to read %s at iteration %d", fname, i)
+			require.Equal(t, []byte(fname), data, "file content mismatch for %s", fname)
 		}
+		// 校验文件树
+		nydusd.VerifyByPath(t, layer.FileTree, curCfg.MountPath)
+
 		err = nydusd.UmountByAPI(curCfg.MountPath)
 		require.NoError(t, err, "failed to unmount by API at iteration %d", i)
 	}
 }
+
+// func (a *APIV1TestSuite) TestSubMountCache(t *testing.T) {
+
+// 	ctx := tool.DefaultContext(t)
+
+// 	ctx.PrepareWorkDir(t)
+// 	defer ctx.Destroy(t)
+
+// 	// lower contains more files than thinLower
+// 	lower := texture.MakeLowerLayer(t, filepath.Join(ctx.Env.WorkDir, "rootfs"))
+// 	thinLower := texture.MakeThinLowerLayer(t, filepath.Join(ctx.Env.WorkDir, "rootfs1"))
+
+// 	lowerBootstrap := a.buildLayer(t, ctx, lower)
+// 	thinLowerBootstrap := a.buildLayer(t, ctx, thinLower)
+
+// 	config := tool.NydusdConfig{
+// 		NydusdPath:  ctx.Binary.Nydusd,
+// 		MountPath:   ctx.Env.MountDir,
+// 		APISockPath: filepath.Join(ctx.Env.WorkDir, "nydusd-api.sock"),
+// 		ConfigPath:  filepath.Join(ctx.Env.WorkDir, "nydusd-config.fusedev.json"),
+// 	}
+
+// 	nydusd, err := tool.NewNydusd(config)
+// 	require.NoError(t, err)
+// 	err = nydusd.Mount()
+// 	require.NoError(t, err)
+// 	defer nydusd.Umount()
+
+// 	// child mount config template (copied every iteration)
+// 	childTpl := tool.NydusdConfig{
+// 		NydusdPath:      ctx.Binary.Nydusd,
+// 		MountPath:       "/mount",
+// 		APISockPath:     filepath.Join(ctx.Env.WorkDir, "nydusd-api.sock"),
+// 		ConfigPath:      filepath.Join(ctx.Env.WorkDir, "nydusd-config.fusedev.json"),
+// 		BackendType:     "localfs",
+// 		BackendConfig:   fmt.Sprintf(`{"dir": "%s"}`, ctx.Env.BlobDir),
+// 		BlobCacheDir:    ctx.Env.CacheDir,
+// 		CacheType:       ctx.Runtime.CacheType,
+// 		CacheCompressed: ctx.Runtime.CacheCompressed,
+// 		RafsMode:        ctx.Runtime.RafsMode,
+// 		EnablePrefetch:  ctx.Runtime.EnablePrefetch,
+// 		DigestValidate:  false,
+// 		AmplifyIO:       ctx.Runtime.AmplifyIO,
+// 	}
+
+// 	// mount prefix where the daemon actually mounts sub-mounts
+// 	mountPrefix := ctx.Env.WorkDir + "/mnt"
+
+// 	// iterate 256 times; first mount uses thinlower (without some files), subsequent mounts use Lower.
+// 	for i := 0; i < 256; i++ {
+// 		curCfg := childTpl
+// 		if i == 0 {
+// 			curCfg.BootstrapPath = thinLowerBootstrap
+// 		} else {
+// 			curCfg.BootstrapPath = lowerBootstrap
+// 		}
+// 		curCfg.MountPath = childTpl.MountPath + fmt.Sprintf("-%d", i)
+// 		err = nydusd.MountByAPI(curCfg)
+// 		require.NoError(t, err, "failed to mount by API at iteration %d", i)
+
+// 		fullMount := filepath.Join(mountPrefix, curCfg.MountPath)
+
+// 		// VerifyByPath validates the file tree and also triggers the construction of inode and dentry caches.
+// 		if i == 0 {
+// 			nydusd.VerifyByPath(t, thinLower.FileTree, curCfg.MountPath)
+// 		} else {
+// 			// Verify specific files exist
+// 			_, err := os.Stat(filepath.Join(fullMount, "dir-1/file-1"))
+// 			require.NoError(t, err, "stat file-1 failed")
+
+// 			// Verify file contents
+// 			data, err := os.ReadFile(filepath.Join(fullMount, "file-2"))
+// 			require.NoError(t, err, "fail to read file-2")
+// 			require.Equal(t, []byte("file-2"), data, "file-2")
+
+// 			//  Verify directory contents
+// 			ents, err := os.ReadDir(filepath.Join(fullMount, "dir-1"))
+// 			require.NoError(t, err, "readdir dir-1 failed")
+
+// 			names := make(map[string]bool)
+// 			for _, e := range ents {
+// 				names[e.Name()] = true
+// 			}
+// 			expected := []string{
+// 				"file-1-hardlink-1",
+// 				"file-1-hardlink-2",
+// 				"file-1-symlink-1",
+// 				"file-1-symlink-2",
+// 				"file-external-1",
+// 				"file-2",
+// 			}
+
+// 			// Ensure directory contains all expected entries
+// 			for _, name := range expected {
+// 				require.True(t, names[name], "dir-1 should contain %s", name)
+// 			}
+
+// 			nydusd.VerifyByPath(t, lower.FileTree, curCfg.MountPath)
+
+//			}
+//			err = nydusd.UmountByAPI(curCfg.MountPath)
+//			require.NoError(t, err, "failed to unmount by API at iteration %d", i)
+//		}
+//	}
 func (a *APIV1TestSuite) TestMount(t *testing.T) {
 
 	ctx := tool.DefaultContext(t)

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { version = "1.19.0", features = [
 ] }
 url = { version = "2.1.1", optional = true }
 vm-memory = "0.14.1"
-fuse-backend-rs = "^0.12.0"
+fuse-backend-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git" }
 gpt = { version = "3.1.0", optional = true }
 
 nydus-api = { version = "0.4.0", path = "../api" }


### PR DESCRIPTION
- Before unmounting a RAFS filesystem, recursively invalidate all inodes and dentries to prevent stale kernel caches when using shared mounts.
- Added a new smoke test `TestSubMountCache` to mount/unmount sub-mounts multiple times (256 iterations) and verify file, directory, symlink, and hardlink correctness, including dangling symlink behavior.

## Overview
_Please briefly describe the changes your pull request makes._

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.